### PR TITLE
Avoid for-of loop to fix Safari error

### DIFF
--- a/dist/react-inline-svg.js
+++ b/dist/react-inline-svg.js
@@ -112,31 +112,8 @@ var SVGCache = (function () {
         item.state = "loaded";
         item.content = data;
 
-        var _iteratorNormalCompletion = true;
-        var _didIteratorError = false;
-        var _iteratorError = undefined;
-
-        try {
-          for (var _iterator = item.subscribers[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-            var subscriber = _step.value;
-
-            if (callback) {
-              callback(subscriber);
-            }
-          }
-        } catch (err) {
-          _didIteratorError = true;
-          _iteratorError = err;
-        } finally {
-          try {
-            if (!_iteratorNormalCompletion && _iterator["return"]) {
-              _iterator["return"]();
-            }
-          } finally {
-            if (_didIteratorError) {
-              throw _iteratorError;
-            }
-          }
+        if (callback) {
+          item.subscribers.forEach(callback);
         }
       });
 

--- a/src/svg-cache.js
+++ b/src/svg-cache.js
@@ -55,10 +55,8 @@ class SVGCache {
       item.state = "loaded";
       item.content = data;
 
-      for(let subscriber of item.subscribers) {
-        if(callback) {
-          callback(subscriber)
-        }
+      if (callback) {
+        item.subscribers.forEach(callback);
       }
     });
 


### PR DESCRIPTION
The for/of loop compiles to code that requires Symbol support, which isn’t [available](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) in Safari. This PR switches to using Array.prototype.forEach, which has wider [browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach). 

An alternate option would be for consumers to use a polyfill, but I didn't see a lot of great options out there. [babel-core](http://babeljs.io/docs/advanced/caveats/) is pretty big, and [es-symbol](https://github.com/goatslacker/es-symbol) assumes `module.exports` is supported.

@loopj let me know what you think! :sparkles: 
